### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.6-alpine
+
+RUN apk --update add make
+
+COPY . /go/src/github.com/wrouesnel/postgres_exporter
+
+WORKDIR /go/src/github.com/wrouesnel/postgres_exporter
+
+RUN make postgres_exporter
+
+ENTRYPOINT [ "./postgres_exporter" ]
+
+EXPOSE 9113


### PR DESCRIPTION
Bypass the custom build script and use a Dockerfile to build the service. 

The docker file is based on Alpine and it's much smaller image than golang:1.6-wheezy