### PR TITLE
Handle `pg_runtime_variable` return values

### DIFF
--- a/postgres_exporter.go
+++ b/postgres_exporter.go
@@ -286,6 +286,10 @@ func makeDescMap(metricMaps map[string]map[string]ColumnMapping) map[string]Metr
 							return math.NaN(), false
 						}
 
+						if durationString == "-1" {
+							return math.NaN(), false
+						}
+
 						d, err := time.ParseDuration(durationString)
 						if err != nil {
 							log.Errorln("Failed converting result to metric:", columnName, in, err)


### PR DESCRIPTION
When querying postgres `pg_runtime_variable`, postgres might return -1
for `max_standby_archive_delay` and `max_standby_streaming_delay`