### PR TITLE
Use tini as a minimal init for the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.4
+
+RUN apk add --update tini
+
+ADD postgres_exporter /
+
+EXPOSE 9113
+
+ENTRYPOINT ["/sbin/tini", "--", "/postgres_exporter"]

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,7 @@ postgres_exporter: $(GO_SRC)
 
 # Take a go build and turn it into a minimal container
 docker: postgres_exporter
-	tar -cf - postgres_exporter | docker import --change "EXPOSE 9113" \
-			--change 'ENTRYPOINT [ "/postgres_exporter" ]' \
-			- $(CONTAINER_NAME)
+	docker build -t $(CONTAINER_NAME) .
 
 vet:
 	go vet .


### PR DESCRIPTION
This PR fixes #12 (so far).

It's based on alpine:3.4 to minimize image size.

Please notice that I only modified the docker make target, docker-build will need to be modified as well.