### PR TITLE
Properly print the SQL server error string in the log message.

### DIFF
--- a/postgres_exporter.go
+++ b/postgres_exporter.go
@@ -984,7 +984,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 
 	// Check if map versions need to be updated
 	if err := e.checkMapVersions(ch, db); err != nil {
-		log.Warnln("Postgres version could not be determined. Proceeding with outdated query maps.")
+		log.Warnln("Proceeding with outdated query maps, as the Postgres version could not be determined:", err)
 		e.error.Set(1)
 	}
 


### PR DESCRIPTION
On a Debian + PostgreSQL 9.4 system I had a hard time getting the
exporter to work. It looks like I was running into some authentication
issues that weren't logged by sql.Open(), but by sql.DB.QueryRow().

This change extends the warning generated by the call to
checkMapVersions() to also print the error message generated by
sql.DB.QueryRow().