### PR TITLE
Improve "Running as non-superuser" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ GRANT SELECT ON postgres_exporter.pg_stat_replication TO postgres_exporter;
 GRANT SELECT ON postgres_exporter.pg_stat_activity TO postgres_exporter;
 ```
 
-> **NOTE **
+> **NOTE**
 > <br />Remember to use `postgres` database name in the connection string:
 > ```
 > DATA_SOURCE_NAME=postgresql://postgres_exporter:password@localhost:5432/postgres?sslmode=disable

--- a/README.md
+++ b/README.md
@@ -108,3 +108,9 @@ AS
 GRANT SELECT ON postgres_exporter.pg_stat_replication TO postgres_exporter;
 GRANT SELECT ON postgres_exporter.pg_stat_activity TO postgres_exporter;
 ```
+
+> **NOTE **
+> <br />Remember to use `postgres` database name in the connection string:
+> ```
+> DATA_SOURCE_NAME=postgresql://postgres_exporter:password@localhost:5432/postgres?sslmode=disable
+> ```


### PR DESCRIPTION
When the database is not added the exporter returns an error:

```
level=warning msg="Proceeding with outdated query maps, as the Postgres version could not be determined: Error scanning version string: pq: database \"postgres_exporter\" does not exist\n" source="postgres_exporter.go:1002
```