### PR TITLE
Use latest minor version of Go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
 - docker
 language: go
 go:
-- '1.7'
+- '1.7.5'
 # Make sure we have p2 and the postgres client.
 before_install:
 - go get -v github.com/mattn/goveralls


### PR DESCRIPTION
I am interested in the postgres_exporter releases built with any Go > 1.7.0 since that should fix the issue https://github.com/golang/go/issues/16739 in Go.