### PR TITLE
Fix Postgres name + optionally grant postgres_exporter role to deployer role

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 [![Coverage Status](https://coveralls.io/repos/github/wrouesnel/postgres_exporter/badge.svg?branch=master)](https://coveralls.io/github/wrouesnel/postgres_exporter?branch=master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/wrouesnel/postgres_exporter)](https://goreportcard.com/report/github.com/wrouesnel/postgres_exporter)
 
-# PostgresSQL Server Exporter
+# PostgreSQL Server Exporter
 
-Prometheus exporter for PostgresSQL server metrics.
+Prometheus exporter for PostgreSQL server metrics.
 Supported Postgres versions: 9.1 and up.
 
 ## Quick Start
@@ -44,7 +44,7 @@ Package vendoring is handled with [`govendor`](https://github.com/kardianos/gove
 
 ### Setting the Postgres server's data source name
 
-The PostgresSQL server's [data source name](http://en.wikipedia.org/wiki/Data_source_name)
+The PostgreSQL server's [data source name](http://en.wikipedia.org/wiki/Data_source_name)
 must be set via the `DATA_SOURCE_NAME` environment variable.
 
 For running it locally on a default Debian/Ubuntu install, this will work (transpose to init script as appropriate):

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ To be able to collect metrics from pg_stat_activity and pg_stat_replication as n
 CREATE USER postgres_exporter PASSWORD 'password';
 ALTER USER postgres_exporter SET SEARCH_PATH TO postgres_exporter,pg_catalog;
 
+-- If deploying as non-superuser (for example in AWS RDS)
+-- GRANT postgres_exporter TO :MASTER_USER;
 CREATE SCHEMA postgres_exporter AUTHORIZATION postgres_exporter;
 
 CREATE FUNCTION postgres_exporter.f_select_pg_stat_activity()


### PR DESCRIPTION
* PostgreSQL name was misspelled in 53b9d9cea7de0d4ae4194e0e52ea2ca10911979b
* If the deployer role is not superuser (which is the case in AWS RDS,
for example), we need to grant it access to postgres_exporter role
before we can create a schema with AUTHORIZATION postgres_exporter.