### PR TITLE
Add ability to get DSN from multiple Cloud Foundry service bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ export DATA_SOURCE_NAME="postgresql://login:password@hostname:port/dbname"
 ./postgres_exporter <flags>
 ```
 
-To build the dockerfile, run `make docker`. 
+To build the dockerfile, run `make docker`.
 
-This will build the docker image as `wrouesnel/postgres_exporter:latest`. This 
-is a minimal docker image containing *just* postgres_exporter. By default no SSL 
-certificates are included, if you need to use SSL you should either bind-mount 
+This will build the docker image as `wrouesnel/postgres_exporter:latest`. This
+is a minimal docker image containing *just* postgres_exporter. By default no SSL
+certificates are included, if you need to use SSL you should either bind-mount
 `/etc/ssl/certs/ca-certificates.crt` or derive a new image containing them.
 
 ### Vendoring
@@ -36,7 +36,7 @@ Package vendoring is handled with [`govendor`](https://github.com/kardianos/gove
 
 ### Flags
 
-* `web.listen-address` 
+* `web.listen-address`
   Address to listen on for web interface and telemetry.
 
 * `web.telemetry-path`
@@ -52,6 +52,11 @@ For running it locally on a default Debian/Ubuntu install, this will work (trans
     sudo -u postgres DATA_SOURCE_NAME="user=postgres host=/var/run/postgresql/ sslmode=disable" postgres_exporter
 
 See the [github.com/lib/pq](http://github.com/lib/pq) module for other ways to format the connection string.
+
+### Using a CF binding
+
+The exporter supports CF binding credentials to get a DSN. If there are multiple bindings of postgresql databases,
+it will use the first one.
 
 ### Adding new metrics
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ For running it locally on a default Debian/Ubuntu install, this will work (trans
 
 See the [github.com/lib/pq](http://github.com/lib/pq) module for other ways to format the connection string.
 
-### Using a CF binding
+### Using a Cloud Foundry binding
 
-The exporter supports CF binding credentials to get a DSN. If there are multiple bindings of postgresql databases,
-it will use the first one.
+The exporter supports CF binding credentials to get a DSN. Multiple postgres bindings are supported by prefixing
+the CF Service Instance name to the metric descriptor name.
 
 ### Adding new metrics
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,4 @@
+---
+buildpack: go_buildpack
+env:
+  GOPACKAGENAME: main

--- a/postgres_exporter_integration_test.go
+++ b/postgres_exporter_integration_test.go
@@ -58,7 +58,7 @@ func (s *IntegrationSuite) TestAllNamespacesReturnResults(c *C) {
 	err = s.e.checkMapVersions(ch, db)
 	c.Assert(err, IsNil)
 
-	err = querySettings(ch, db)
+	err = querySettings("", ch, db)
 	if !c.Check(err, Equals, nil) {
 		fmt.Println("## ERRORS FOUND")
 		fmt.Println(err)

--- a/postgres_exporter_test.go
+++ b/postgres_exporter_test.go
@@ -3,8 +3,9 @@
 package main
 
 import (
-	. "gopkg.in/check.v1"
 	"testing"
+
+	. "gopkg.in/check.v1"
 
 	"github.com/blang/semver"
 )
@@ -31,7 +32,7 @@ func (s *FunctionalSuite) TestSemanticVersionColumnDiscard(c *C) {
 
 	{
 		// No metrics should be eliminated
-		resultMap := makeDescMap(semver.MustParse("0.0.1"), testMetricMap)
+		resultMap := makeDescMap("", semver.MustParse("0.0.1"), testMetricMap)
 		c.Check(
 			resultMap["test_namespace"].columnMappings["metric_which_stays"].discard,
 			Equals,
@@ -51,7 +52,7 @@ func (s *FunctionalSuite) TestSemanticVersionColumnDiscard(c *C) {
 		testMetricMap["test_namespace"]["metric_which_discards"] = discardableMetric
 
 		// Discard metric should be discarded
-		resultMap := makeDescMap(semver.MustParse("0.0.1"), testMetricMap)
+		resultMap := makeDescMap("", semver.MustParse("0.0.1"), testMetricMap)
 		c.Check(
 			resultMap["test_namespace"].columnMappings["metric_which_stays"].discard,
 			Equals,
@@ -71,7 +72,7 @@ func (s *FunctionalSuite) TestSemanticVersionColumnDiscard(c *C) {
 		testMetricMap["test_namespace"]["metric_which_discards"] = discardableMetric
 
 		// Discard metric should be discarded
-		resultMap := makeDescMap(semver.MustParse("0.0.2"), testMetricMap)
+		resultMap := makeDescMap("", semver.MustParse("0.0.2"), testMetricMap)
 		c.Check(
 			resultMap["test_namespace"].columnMappings["metric_which_stays"].discard,
 			Equals,

--- a/vendor/github.com/gnhuy91/go-vcap-parser/LICENSE
+++ b/vendor/github.com/gnhuy91/go-vcap-parser/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Huy Giang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/gnhuy91/go-vcap-parser/README.md
+++ b/vendor/github.com/gnhuy91/go-vcap-parser/README.md
@@ -1,0 +1,2 @@
+# go-vcap-parser
+Small package to parse Cloud Foundry's VCAP environment variables to Go structs.

--- a/vendor/github.com/gnhuy91/go-vcap-parser/vcapparser.go
+++ b/vendor/github.com/gnhuy91/go-vcap-parser/vcapparser.go
@@ -1,0 +1,48 @@
+package vcapparser
+
+import "encoding/json"
+
+type Credentials struct {
+	// Genenal field
+	URI string `json:"uri,omitempty"`
+	// Postgres service
+	ID         int    `json:"ID,omitempty"`
+	BindingID  string `json:"binding_id,omitempty"`
+	Database   string `json:"database,omitempty"`
+	DSN        string `json:"dsn,omitempty"`
+	Host       string `json:"host,omitempty"`
+	InstanceID string `json:"instance_id,omitempty"`
+	JdbcURI    string `json:"jdbc_uri,omitempty"`
+	Password   string `json:"password,omitempty"`
+	Port       string `json:"port,omitempty"`
+	Username   string `json:"username,omitempty"`
+	// UAA service
+	IssuerID  string            `json:"issuerId,omitempty"`
+	Subdomain string            `json:"subdomain,omitempty"`
+	Zone      map[string]string `json:"zone,omitempty"`
+}
+
+type VcapService struct {
+	Credentials    Credentials `json:"credentials"`
+	Label          string      `json:"label"`
+	Name           string      `json:"name"`
+	Plan           string      `json:"plan"`
+	Provider       string      `json:"provider"`
+	SyslogDrainURL string      `json:"syslog_drain_url"`
+	Tags           []string    `json:"tags"`
+}
+
+// VcapServices is a map of services detail
+type VcapServices map[string][]VcapService
+
+// ParseVcapServices parse string provided from VCAP_SERVICES environment var
+// to VcapServices struct.
+func ParseVcapServices(vcapStr string) (VcapServices, error) {
+	var vcapServices VcapServices
+
+	if err := json.Unmarshal([]byte(vcapStr), &vcapServices); err != nil {
+		return vcapServices, err
+	}
+
+	return vcapServices, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -19,6 +19,12 @@
 			"revisionTime": "2016-07-01T05:46:53Z"
 		},
 		{
+			"checksumSHA1": "bRXf5RCqT6YMfv9B/Cbi6NhwCSo=",
+			"path": "github.com/gnhuy91/go-vcap-parser",
+			"revision": "3620995c699eb5d16d3e60805191995396952b66",
+			"revisionTime": "2016-07-06T07:58:25Z"
+		},
+		{
 			"path": "github.com/golang/protobuf/proto",
 			"revision": "68415e7123da32b07eab49c96d2c4d6158360e9b",
 			"revisionTime": "2015-12-07T15:07:14+11:00"


### PR DESCRIPTION
This enables the service (if `DATA_SOURCE_NAME` is not specified) to try to parse `VCAP_SERVICES` in order to get all bound postgres services.
If it finds some, it will retrieve the URIs and enable multiple exporters. This is while `userQueriesPath`-file will be applied to each of them and it will search for a file with name `<cf-service-instance-name>.yml`, which will be individually added.