### PR TITLE
Postgres 10 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ run-tests: tools
 	mkdir -p $(COVERDIR)
 	rm -f $(COVERDIR)/*
 	for pkg in $(GO_PKGS) ; do \
-		go test -v -covermode count -coverprofile=$(COVERDIR)/$$(echo $$pkg | tr '/' '-').out $$pkg ; \
+		go test -v -covermode count -coverprofile=$(COVERDIR)/$$(echo $$pkg | tr '/' '-').out $$pkg || exit 1 ; \
 	done
 
 test: run-tests
@@ -65,7 +65,7 @@ docker-build:
 	    -v $(shell pwd):/real_src \
 	    -e SHELL_UID=$(shell id -u) -e SHELL_GID=$(shell id -g) \
 	    -w /go/src/github.com/wrouesnel/postgres_exporter \
-		golang:1.8-wheezy \
+		golang:1.9-wheezy \
 		/bin/bash -c "make >&2 && chown $$SHELL_UID:$$SHELL_GID ./postgres_exporter"
 	docker build -t $(CONTAINER_NAME) .
 

--- a/postgres_exporter.go
+++ b/postgres_exporter.go
@@ -102,7 +102,7 @@ func (cu *ColumnUsage) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // Regex used to get the "short-version" from the postgres version field.
-var versionRegex = regexp.MustCompile(`^\w+ (\d+\.\d+\.\d+)`)
+var versionRegex = regexp.MustCompile(`^\w+ ((\d+)(\.\d+)?(\.\d+)?)\s`)
 var lowestSupportedVersion = semver.MustParse("9.1.0")
 
 // Parses the version of postgres into the short version string we can use to
@@ -110,7 +110,7 @@ var lowestSupportedVersion = semver.MustParse("9.1.0")
 func parseVersion(versionString string) (semver.Version, error) {
 	submatches := versionRegex.FindStringSubmatch(versionString)
 	if len(submatches) > 1 {
-		return semver.Make(submatches[1])
+		return semver.ParseTolerant(submatches[1])
 	}
 	return semver.Version{},
 		errors.New(fmt.Sprintln("Could not find a postgres version in string:", versionString))

--- a/postgres_exporter.go
+++ b/postgres_exporter.go
@@ -225,10 +225,14 @@ var builtinMetricMaps = map[string]map[string]ColumnMapping{
 		"backend_start": {DISCARD, "with time zone	Time when cu process was started, i.e., when the client connected to cu WAL sender", nil, nil},
 		"backend_xmin":             {DISCARD, "The current backend's xmin horizon.", nil, nil},
 		"state":                    {LABEL, "Current WAL sender state", nil, nil},
-		"sent_location":            {DISCARD, "Last transaction log position sent on cu connection", nil, nil},
-		"write_location":           {DISCARD, "Last transaction log position written to disk by cu standby server", nil, nil},
-		"flush_location":           {DISCARD, "Last transaction log position flushed to disk by cu standby server", nil, nil},
-		"replay_location":          {DISCARD, "Last transaction log position replayed into the database on cu standby server", nil, nil},
+		"sent_location":            {DISCARD, "Last transaction log position sent on cu connection", nil, semver.MustParseRange("<10.0.0")},
+		"write_location":           {DISCARD, "Last transaction log position written to disk by cu standby server", nil, semver.MustParseRange("<10.0.0")},
+		"flush_location":           {DISCARD, "Last transaction log position flushed to disk by cu standby server", nil, semver.MustParseRange("<10.0.0")},
+		"replay_location":          {DISCARD, "Last transaction log position replayed into the database on cu standby server", nil, semver.MustParseRange("<10.0.0")},
+		"sent_lsn":                 {DISCARD, "Last transaction log position sent on cu connection", nil, semver.MustParseRange(">=10.0.0")},
+		"write_lsn":                {DISCARD, "Last transaction log position written to disk by cu standby server", nil, semver.MustParseRange(">=10.0.0")},
+		"flush_lsn":                {DISCARD, "Last transaction log position flushed to disk by cu standby server", nil, semver.MustParseRange(">=10.0.0")},
+		"replay_lsn":               {DISCARD, "Last transaction log position replayed into the database on cu standby server", nil, semver.MustParseRange(">=10.0.0")},
 		"sync_priority":            {DISCARD, "Priority of cu standby server for being chosen as the synchronous standby", nil, nil},
 		"sync_state":               {DISCARD, "Synchronous state of cu standby server", nil, nil},
 		"slot_name":                {LABEL, "A unique, cluster-wide identifier for the replication slot", nil, semver.MustParseRange(">=9.2.0")},
@@ -242,8 +246,13 @@ var builtinMetricMaps = map[string]map[string]ColumnMapping{
 		"catalog_xmin":             {DISCARD, "The oldest transaction affecting the system catalogs that cu slot needs the database to retain. VACUUM cannot remove catalog tuples deleted by any later transaction", nil, nil},
 		"restart_lsn":              {DISCARD, "The address (LSN) of oldest WAL which still might be required by the consumer of cu slot and thus won't be automatically removed during checkpoints", nil, nil},
 		"pg_current_xlog_location": {DISCARD, "pg_current_xlog_location", nil, nil},
-		"pg_xlog_location_diff":    {GAUGE, "Lag in bytes between master and slave", nil, semver.MustParseRange(">=9.2.0")},
+		"pg_current_wal_lsn":       {DISCARD, "pg_current_xlog_location", nil, semver.MustParseRange(">=10.0.0")},
+		"pg_xlog_location_diff":    {GAUGE, "Lag in bytes between master and slave", nil, semver.MustParseRange(">=9.2.0 <10.0.0")},
+		"pg_wal_lsn_diff":          {GAUGE, "Lag in bytes between master and slave", nil, semver.MustParseRange(">=10.0.0")},
 		"confirmed_flush_lsn":      {DISCARD, "LSN position a consumer of a slot has confirmed flushing the data received", nil, nil},
+		"write_lag":                {DISCARD, "Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written it (but not yet flushed it or applied it). This can be used to gauge the delay that synchronous_commit level remote_write incurred while committing if this server was configured as a synchronous standby.", nil, semver.MustParseRange(">=10.0.0")},
+		"flush_lag":                {DISCARD, "Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written and flushed it (but not yet applied it). This can be used to gauge the delay that synchronous_commit level remote_flush incurred while committing if this server was configured as a synchronous standby.", nil, semver.MustParseRange(">=10.0.0")},
+		"replay_lag":               {DISCARD, "Time elapsed between flushing recent WAL locally and receiving notification that this standby server has written, flushed and applied it. This can be used to gauge the delay that synchronous_commit level remote_apply incurred while committing if this server was configured as a synchronous standby.", nil, semver.MustParseRange(">=10.0.0")},
 	},
 	"pg_stat_activity": {
 		"datname":         {LABEL, "Name of cu database", nil, nil},
@@ -291,7 +300,16 @@ var queryOverrides = map[string][]OverrideQuery{
 
 	"pg_stat_replication": {
 		{
-			semver.MustParseRange(">=9.2.0"),
+			semver.MustParseRange(">=10.0.0"),
+			`
+			SELECT *,
+				(case pg_is_in_recovery() when 't' then null else pg_current_wal_lsn() end) AS pg_current_wal_lsn,
+				(case pg_is_in_recovery() when 't' then null else pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn)::float end) AS pg_wal_lsn_diff
+			FROM pg_stat_replication
+			`,
+		},
+		{
+			semver.MustParseRange(">=9.2.0 <10.0.0"),
 			`
 			SELECT *,
 				(case pg_is_in_recovery() when 't' then null else pg_current_xlog_location() end) AS pg_current_xlog_location,
@@ -627,6 +645,7 @@ func dbToFloat64(t interface{}) (float64, bool) {
 		strV := string(v)
 		result, err := strconv.ParseFloat(strV, 64)
 		if err != nil {
+			log.Infoln("Could not parse []byte:", err)
 			return math.NaN(), false
 		}
 		return result, true
@@ -850,7 +869,6 @@ func queryNamespaceMapping(ch chan<- prometheus.Metric, db *sql.DB, namespace st
 					nonfatalErrors = append(nonfatalErrors, errors.New(fmt.Sprintln("Unparseable column type - discarding: ", namespace, columnName, err)))
 					continue
 				}
-				log.Debugln(columnName, labels)
 				ch <- prometheus.MustNewConstMetric(desc, prometheus.UntypedValue, value, labels...)
 			}
 		}

--- a/postgres_exporter_integration_test_script
+++ b/postgres_exporter_integration_test_script
@@ -10,6 +10,6 @@ shift
 echo "mode: count" > $output_cov
 
 test_cov=$(mktemp)
-$test_binary -test.coverprofile=$test_cov $@
+$test_binary -test.coverprofile=$test_cov $@ || exit 1
 tail -n +2 $test_cov >> $output_cov
 rm -f $test_cov

--- a/tests/test-smoke
+++ b/tests/test-smoke
@@ -26,6 +26,7 @@ VERSIONS=( \
     9.4 \
     9.5 \
     9.6 \
+    10 \
 )
 
 wait_for_postgres(){

--- a/tests/test-smoke
+++ b/tests/test-smoke
@@ -76,18 +76,20 @@ smoketest_postgres() {
     echo "#######################"
     echo "Standalone Postgres $version"
     echo "#######################"
-    local docker_cmd="docker run -d -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -p 127.0.0.1:55432:5432 $CUR_IMAGE"
+    local docker_cmd="docker run -d -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD $CUR_IMAGE"
     echo "Docker Cmd: $docker_cmd"
     
     CONTAINER_NAME=$($docker_cmd)
+    standalone_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $CONTAINER_NAME)
     trap "docker logs $CONTAINER_NAME ; docker kill $CONTAINER_NAME ; docker rm -v $CONTAINER_NAME; exit 1" EXIT INT TERM
-    wait_for_postgres localhost 55432
+    wait_for_postgres $standalone_ip 5432
+
 
     # Run the test binary.
-    DATA_SOURCE_NAME="postgresql://postgres:$POSTGRES_PASSWORD@localhost:55432/?sslmode=disable" $test_binary --log.level=debug || exit $?
+    DATA_SOURCE_NAME="postgresql://postgres:$POSTGRES_PASSWORD@$standalone_ip:5432/?sslmode=disable" $test_binary --log.level=debug || exit $?
 
     # Extract a raw metric list.
-    DATA_SOURCE_NAME="postgresql://postgres:$POSTGRES_PASSWORD@localhost:55432/?sslmode=disable" $postgres_exporter --log.level=debug --web.listen-address=:$exporter_port &
+    DATA_SOURCE_NAME="postgresql://postgres:$POSTGRES_PASSWORD@$standalone_ip:5432/?sslmode=disable" $postgres_exporter --log.level=debug --web.listen-address=:$exporter_port &
     exporter_pid=$!
     trap "docker logs $CONTAINER_NAME ; docker kill $CONTAINER_NAME ; docker rm -v $CONTAINER_NAME; kill $exporter_pid; exit 1" EXIT INT TERM
     wait_for_exporter


### PR DESCRIPTION
Add Postgres 10 as a smoke-tested version and add explicit support.

Closes #119 #111 #91

TODOs: some of the new time metrics would be worthwhile to parse, but will be handled in a future PR.