### PR TITLE
Fix panic due to inconsistent label cardinality when using queries.yaml.

### DIFF
--- a/postgres_exporter.go
+++ b/postgres_exporter.go
@@ -837,7 +837,8 @@ func queryNamespaceMapping(ch chan<- prometheus.Metric, db *sql.DB, namespace st
 				ch <- prometheus.MustNewConstMetric(metricMapping.desc, metricMapping.vtype, value, labels...)
 			} else {
 				// Unknown metric. Report as untyped if scan to float64 works, else note an error too.
-				desc := prometheus.NewDesc(fmt.Sprintf("%s_%s", namespace, columnName), fmt.Sprintf("Unknown metric from %s", namespace), nil, nil)
+				metricLabel := fmt.Sprintf("%s_%s", namespace, columnName)
+				desc := prometheus.NewDesc(metricLabel, fmt.Sprintf("Unknown metric from %s", namespace), mapping.labels, nil)
 
 				// Its not an error to fail here, since the values are
 				// unexpected anyway.


### PR DESCRIPTION
When using queries.yaml, extra columns in the output would be detected as
unknown metrics (correctly) but the labels in the current mapping would not be
applied to the output.

This explains the rash of crashes due to inconsistent label cardinality. The
specific creation is when the name given to a column does not match the mapping
you intended, and so the metric shows up as unknown.

Closes #98