### PR TITLE
Ensure pg_up is always set to 0 when the initial database connection fails

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -969,15 +969,12 @@ func (e *Exporter) getDB(conn string) (*sql.DB, error) {
 	if e.dbConnection == nil {
 		d, err := sql.Open("postgres", conn)
 		if err != nil {
-			e.psqlUp.Set(0)
 			return nil, err
 		}
 		err = d.Ping()
 		if err != nil {
-			e.psqlUp.Set(0)
 			return nil, err
 		}
-		e.psqlUp.Set(1)
 
 		d.SetMaxOpenConns(1)
 		d.SetMaxIdleConns(1)
@@ -1011,6 +1008,7 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		}
 		log.Infof("Error opening connection to database (%s): %s", loggableDsn, err)
 		e.error.Set(1)
+		e.psqlUp.Set(0) // Force "up" to 0 here.
 		return
 	}
 


### PR DESCRIPTION
This did in fact turn out to be an oversight in the error handling. Now, any
error in the initial connection path will always trip pg_up to be 0.

Fixes #160