### PR TITLE
FreeBSD compilation target

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -101,6 +101,7 @@ var platforms []Platform = []Platform{
 	{"darwin", "386", ""},
 	{"windows", "amd64", ".exe"},
 	{"windows", "386", ".exe"},
+	{"freebsd", "amd64", ""},
 }
 
 // productName can be overridden by environ product name


### PR DESCRIPTION
Added FreeBSD as a building target. Tested cross-compiling on local machine and moved binary to FreeBSD target, which ran it without problems.