### PR TITLE
URL encode username/password fields

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -1086,8 +1086,9 @@ func getDataSource() string {
 			pass = os.Getenv("DATA_SOURCE_PASS")
 		}
 
+		ui := url.UserPassword(user, pass).String()
 		uri := os.Getenv("DATA_SOURCE_URI")
-		dsn = "postgresql://" + user + ":" + pass + "@" + uri
+		dsn = "postgresql://" + ui + "@" + uri
 	}
 
 	return dsn

--- a/cmd/postgres_exporter/postgres_exporter_test.go
+++ b/cmd/postgres_exporter/postgres_exporter_test.go
@@ -105,7 +105,7 @@ func (s *FunctionalSuite) TestEnvironmentSettingWithSecretsFiles(c *C) {
 	c.Assert(err, IsNil)
 	defer UnsetEnvironment(c, "DATA_SOURCE_URI")
 
-	var expected = "postgresql://custom_username:custom_password@localhost:5432/?sslmode=disable"
+	var expected = "postgresql://custom_username$&+,%2F%3A;=%3F%40:custom_password$&+,%2F%3A;=%3F%40@localhost:5432/?sslmode=disable"
 
 	dsn := getDataSource()
 	if dsn != expected {

--- a/cmd/postgres_exporter/tests/username_file
+++ b/cmd/postgres_exporter/tests/username_file
@@ -1,1 +1,1 @@
-custom_username
+custom_username$&+,/:;=?@

--- a/cmd/postgres_exporter/tests/userpass_file
+++ b/cmd/postgres_exporter/tests/userpass_file
@@ -1,1 +1,1 @@
-custom_password
+custom_password$&+,/:;=?@


### PR DESCRIPTION
Fixes #188.

It occurs to me that you might have a concern about this changing behaviour in the case where existing users have worked around the problem by URL encoding the password themselves before supplying it (it will double encode resulting in authentication failure). If that's the case, I can change the PR so that it only applies the encoding if it detects that it is necessary; this should leave existing unaffected users unaffected, but also fix the problem for those that are.