### PR TITLE
Support for boolean data types as metrics

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -649,6 +649,11 @@ func dbToFloat64(t interface{}) (float64, bool) {
 			return math.NaN(), false
 		}
 		return result, true
+	case bool:
+		if v {
+			return 1.0, true
+		}
+		return 0.0, true
 	case nil:
 		return math.NaN(), true
 	default:
@@ -672,6 +677,11 @@ func dbToString(t interface{}) (string, bool) {
 		return string(v), true
 	case string:
 		return v, true
+	case bool:
+		if v {
+			return "true", true
+		}
+		return "false", true
 	default:
 		return "", false
 	}

--- a/cmd/postgres_exporter/postgres_exporter_test.go
+++ b/cmd/postgres_exporter/postgres_exporter_test.go
@@ -267,3 +267,39 @@ func UnsetEnvironment(c *C, d string) {
 	err := os.Unsetenv(d)
 	c.Assert(err, IsNil)
 }
+
+// test boolean metric type gets converted to float
+func (s *FunctionalSuite) TestBooleanConversionToValueAndString(c *C) {
+
+	type TestCase struct {
+		input          interface{}
+		expectedString string
+		expectedValue  float64
+		expectedOK     bool
+	}
+
+	cases := []TestCase{
+		{
+			input:          true,
+			expectedString: "true",
+			expectedValue:  1.0,
+			expectedOK:     true,
+		},
+		{
+			input:          false,
+			expectedString: "false",
+			expectedValue:  0.0,
+			expectedOK:     true,
+		},
+	}
+
+	for _, cs := range cases {
+		value, ok := dbToFloat64(cs.input)
+		c.Assert(value, Equals, cs.expectedValue)
+		c.Assert(ok, Equals, cs.expectedOK)
+
+		str, ok := dbToString(cs.input)
+		c.Assert(str, Equals, cs.expectedString)
+		c.Assert(ok, Equals, cs.expectedOK)
+	}
+}


### PR DESCRIPTION

This is useful if your database uses true/false for state and want to make prometheus alerts based on that.
Before, booleans were not able to be parsed.  See issue #201 
