### PR TITLE
Feature/disable settings metrics flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Package vendoring is handled with [`govendor`](https://github.com/kardianos/gove
 * `disable-default-metrics`
   Use only metrics supplied from `queries.yaml` via `--extend.query-path`
 
+* `disable-settings-metrics`
+  Disables the exposure of the pg_settings table
+
 * `extend.query-path`
   Path to a YAML file containing custom queries to run. Check out [`queries.yaml`](queries.yaml)
   for examples of the format.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ The following environment variables configure the exporter:
 * `PG_EXPORTER_DISABLE_DEFAULT_METRICS`
   Use only metrics supplied from `queries.yaml`. Value can be `true` or `false`. Default is `false`.
 
+* `PG_EXPORTER_DISABLE_SETTINGS_METRICS`
+  Disables the exposure of the pg_settings table. Value can be `true` or `false`. Default is `false`.
+
 * `PG_EXPORTER_EXTEND_QUERY_PATH`
   Path to a YAML file containing custom queries to run. Check out [`queries.yaml`](queries.yaml)
   for examples of the format.

--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -33,12 +33,13 @@ import (
 var Version = "0.0.1"
 
 var (
-	listenAddress         = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9187").OverrideDefaultFromEnvar("PG_EXPORTER_WEB_LISTEN_ADDRESS").String()
-	metricPath            = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").OverrideDefaultFromEnvar("PG_EXPORTER_WEB_TELEMETRY_PATH").String()
-	disableDefaultMetrics = kingpin.Flag("disable-default-metrics", "Do not include default metrics.").Default("false").OverrideDefaultFromEnvar("PG_EXPORTER_DISABLE_DEFAULT_METRICS").Bool()
-	queriesPath           = kingpin.Flag("extend.query-path", "Path to custom queries to run.").Default("").OverrideDefaultFromEnvar("PG_EXPORTER_EXTEND_QUERY_PATH").String()
-	onlyDumpMaps          = kingpin.Flag("dumpmaps", "Do not run, simply dump the maps.").Bool()
-	constantLabelsList    = kingpin.Flag("constantLabels", "A list of label=value separated by comma(,).").Default("").OverrideDefaultFromEnvar("PG_EXPORTER_CONTANT_LABELS").String()
+	listenAddress          = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9187").OverrideDefaultFromEnvar("PG_EXPORTER_WEB_LISTEN_ADDRESS").String()
+	metricPath             = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").OverrideDefaultFromEnvar("PG_EXPORTER_WEB_TELEMETRY_PATH").String()
+	disableDefaultMetrics  = kingpin.Flag("disable-default-metrics", "Do not include default metrics.").Default("false").OverrideDefaultFromEnvar("PG_EXPORTER_DISABLE_DEFAULT_METRICS").Bool()
+	disableSettingsMetrics = kingpin.Flag("disable-settings-metrics", "Do not include settings metrics.").Default("false").OverrideDefaultFromEnvar("PG_EXPORTER_DISABLE_SETTINGS_METRICS").Bool()
+	queriesPath            = kingpin.Flag("extend.query-path", "Path to custom queries to run.").Default("").OverrideDefaultFromEnvar("PG_EXPORTER_EXTEND_QUERY_PATH").String()
+	onlyDumpMaps           = kingpin.Flag("dumpmaps", "Do not run, simply dump the maps.").Bool()
+	constantLabelsList     = kingpin.Flag("constantLabels", "A list of label=value separated by comma(,).").Default("").OverrideDefaultFromEnvar("PG_EXPORTER_CONTANT_LABELS").String()
 )
 
 // Metric name parts.
@@ -682,14 +683,15 @@ type Exporter struct {
 	// only, since it just points to the global.
 	builtinMetricMaps map[string]map[string]ColumnMapping
 
-	dsn                   string
-	disableDefaultMetrics bool
-	userQueriesPath       string
-	duration              prometheus.Gauge
-	error                 prometheus.Gauge
-	psqlUp                prometheus.Gauge
-	userQueriesError      *prometheus.GaugeVec
-	totalScrapes          prometheus.Counter
+	dsn                    string
+	disableDefaultMetrics  bool
+	disableSettingsMetrics bool
+	userQueriesPath        string
+	duration               prometheus.Gauge
+	error                  prometheus.Gauge
+	psqlUp                 prometheus.Gauge
+	userQueriesError       *prometheus.GaugeVec
+	totalScrapes           prometheus.Counter
 
 	// dbDsn is the connection string used to establish the dbConnection
 	dbDsn string
@@ -707,12 +709,13 @@ type Exporter struct {
 }
 
 // NewExporter returns a new PostgreSQL exporter for the provided DSN.
-func NewExporter(dsn string, disableDefaultMetrics bool, userQueriesPath string) *Exporter {
+func NewExporter(dsn string, disableDefaultMetrics bool, disableSettingsMetrics bool, userQueriesPath string) *Exporter {
 	return &Exporter{
-		builtinMetricMaps: builtinMetricMaps,
-		dsn:               dsn,
-		disableDefaultMetrics: disableDefaultMetrics,
-		userQueriesPath:       userQueriesPath,
+		builtinMetricMaps:      builtinMetricMaps,
+		dsn:                    dsn,
+		disableDefaultMetrics:  disableDefaultMetrics,
+		disableSettingsMetrics: disableSettingsMetrics,
+		userQueriesPath:        userQueriesPath,
 		duration: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace:   namespace,
 			Subsystem:   exporter,
@@ -1085,9 +1088,12 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 	// Lock the exporter maps
 	e.mappingMtx.RLock()
 	defer e.mappingMtx.RUnlock()
-	if err := querySettings(ch, db); err != nil {
-		log.Infof("Error retrieving settings: %s", err)
-		e.error.Set(1)
+
+	if !e.disableSettingsMetrics {
+		if err := querySettings(ch, db); err != nil {
+			log.Infof("Error retrieving settings: %s", err)
+			e.error.Set(1)
+		}
 	}
 
 	errMap := queryNamespaceMappings(ch, db, e.metricMap, e.queryOverrides)
@@ -1160,7 +1166,7 @@ func main() {
 		log.Fatal("couldn't find environment variables describing the datasource to use")
 	}
 
-	exporter := NewExporter(dsn, *disableDefaultMetrics, *queriesPath)
+	exporter := NewExporter(dsn, *disableDefaultMetrics, *disableSettingsMetrics, *queriesPath)
 	defer func() {
 		if exporter.dbConnection != nil {
 			exporter.dbConnection.Close() // nolint: errcheck

--- a/cmd/postgres_exporter/postgres_exporter_integration_test.go
+++ b/cmd/postgres_exporter/postgres_exporter_integration_test.go
@@ -31,7 +31,7 @@ func (s *IntegrationSuite) SetUpSuite(c *C) {
 	dsn := os.Getenv("DATA_SOURCE_NAME")
 	c.Assert(dsn, Not(Equals), "")
 
-	exporter := NewExporter(dsn, false, "")
+	exporter := NewExporter(dsn, false, false, "")
 	c.Assert(exporter, NotNil)
 	// Assign the exporter to the suite
 	s.e = exporter
@@ -86,12 +86,12 @@ func (s *IntegrationSuite) TestInvalidDsnDoesntCrash(c *C) {
 	}()
 
 	// Send a bad DSN
-	exporter := NewExporter("invalid dsn", false, *queriesPath)
+	exporter := NewExporter("invalid dsn", false, false, *queriesPath)
 	c.Assert(exporter, NotNil)
 	exporter.scrape(ch)
 
 	// Send a DSN to a non-listening port.
-	exporter = NewExporter("postgresql://nothing:nothing@127.0.0.1:1/nothing", false, *queriesPath)
+	exporter = NewExporter("postgresql://nothing:nothing@127.0.0.1:1/nothing", false, false, *queriesPath)
 	c.Assert(exporter, NotNil)
 	exporter.scrape(ch)
 }
@@ -109,7 +109,7 @@ func (s *IntegrationSuite) TestUnknownMetricParsingDoesntCrash(c *C) {
 	dsn := os.Getenv("DATA_SOURCE_NAME")
 	c.Assert(dsn, Not(Equals), "")
 
-	exporter := NewExporter(dsn, false, "")
+	exporter := NewExporter(dsn, false, false, "")
 	c.Assert(exporter, NotNil)
 
 	// Convert the default maps into a list of empty maps.


### PR DESCRIPTION
This is just a simple flag that skips the pg_settings query. It was added to disable the exporter from exposing the settings found in the table.