### PR TITLE
added a flag to disable the collection of pg_settings as metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Package vendoring is handled with [`govendor`](https://github.com/kardianos/gove
 
 * `web.telemetry-path`
   Path under which to expose metrics. Default is `/metrics`.
+  
+* `collect-settings-metrics`
+  Collect Metrics from pg_settings table.  Default is `true`.  You may disable this collection via `--collect-settings-metrics=false`.
 
 * `disable-default-metrics`
   Use only metrics supplied from `queries.yaml` via `--extend.query-path`
@@ -98,6 +101,9 @@ The following environment variables configure the exporter:
 
 * `PG_EXPORTER_WEB_TELEMETRY_PATH`
   Path under which to expose metrics. Default is `/metrics`.
+  
+* `PG_EXPORTER_COLLECT_SETTINGS_METRICS`
+  Collect metrics supplied from pg_settings. Value can be `true` or `false`. Default is `true`.
 
 * `PG_EXPORTER_DISABLE_DEFAULT_METRICS`
   Use only metrics supplied from `queries.yaml`. Value can be `true` or `false`. Default is `false`.


### PR DESCRIPTION
looking for more ways to reduce the amount of metrics coming into the system, I was toying around with the `disableDefaultMetrics`, only to realize that the settings were still being collected.  Since I have no use for the settings, was wondering if it was at all possible to disable the collection of these settings through a similar argument.

btw, thanks for making work on this exporter...love it!