### PR TITLE
Update non-superuser SQL commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,14 @@ ALTER USER postgres_exporter SET SEARCH_PATH TO postgres_exporter,pg_catalog;
 -- If deploying as non-superuser (for example in AWS RDS), uncomment the GRANT
 -- line below and replace <MASTER_USER> with your root user.
 -- GRANT postgres_exporter TO <MASTER_USER>
-CREATE SCHEMA postgres_exporter AUTHORIZATION postgres_exporter;
+CREATE SCHEMA IF NOT EXISTS postgres_exporter AUTHORIZATION postgres_exporter;
 
-CREATE VIEW postgres_exporter.pg_stat_activity
-AS
+CREATE OR REPLACE VIEW postgres_exporter.pg_stat_activity AS
   SELECT * from pg_catalog.pg_stat_activity;
 
 GRANT SELECT ON postgres_exporter.pg_stat_activity TO postgres_exporter;
 
-CREATE VIEW postgres_exporter.pg_stat_replication AS
+CREATE OR REPLACE VIEW postgres_exporter.pg_stat_replication AS
   SELECT * from pg_catalog.pg_stat_replication;
 
 GRANT SELECT ON postgres_exporter.pg_stat_replication TO postgres_exporter;


### PR DESCRIPTION
This makes the commands for running as non-superuser able to be re-run without as many errors.

This was tested as working on PG 9.4, so should be fairly stable.

This will help those who (like me) are automating these commands as part of a deployment, so we don't need to dive through postgresql docs. I don't think it will affect those running them only once.

I admit it doesn't simply fix the CREATE ROLE failing because the user already exists, but PG doesn't have a good way to do that as far as I could see. It's better than nothing anyway.