### PR TITLE
No need to truncate replication lag to integers

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -1,5 +1,5 @@
 pg_replication:
-  query: "SELECT EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))::INT as lag"
+  query: "SELECT EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())) as lag"
   metrics:
     - lag:
         usage: "GAUGE"


### PR DESCRIPTION
Prometheus supports double/float numbers just fine so no need to truncate the number. Without this you get millisecond (or less?) resolution for your replication lag