### PR TITLE
No version when default metrics disabled

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -1231,8 +1231,10 @@ func (e *Exporter) checkMapVersions(ch chan<- prometheus.Metric, server *Server)
 	versionDesc := prometheus.NewDesc(fmt.Sprintf("%s_%s", namespace, staticLabelName),
 		"Version string as reported by postgres", []string{"version", "short_version"}, server.labels)
 
-	ch <- prometheus.MustNewConstMetric(versionDesc,
-		prometheus.UntypedValue, 1, versionString, semanticVersion.String())
+	if !e.disableDefaultMetrics {
+		ch <- prometheus.MustNewConstMetric(versionDesc,
+			prometheus.UntypedValue, 1, versionString, semanticVersion.String())
+	}
 	return nil
 }
 


### PR DESCRIPTION
Quick fix, to disable collection of static_version if default metrics are disabled.
It throws an error, when connected to multiple databases on same server:

```
# curl localhost:19201/metrics
An error has occurred while serving metrics:

collected metric "pg_static" { label:<name:"server" value:"172.16.110.20:5432" > label:<name:"short_version" value:"11.2.0" > label:<name:"version" value:"PostgreSQL 11.2 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-36), 64-bit" > untyped:<value:1 > } was collected before with the same name and label values

```