### PR TITLE
remove unsupported postgres versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Prometheus exporter for PostgreSQL server metrics.
 
-CI Tested PostgreSQL versions: `9.1`, `9.2`, `9.3`, `9.4`, `9.5`, `9.6`, `10`, `11`
+CI Tested PostgreSQL versions: `9.4`, `9.5`, `9.6`, `10`, `11`
 
 ## Quick Start
 This package is available for Docker:

--- a/cmd/postgres_exporter/tests/test-smoke
+++ b/cmd/postgres_exporter/tests/test-smoke
@@ -26,9 +26,6 @@ echo "Test Binary: $test_binary" 1>&2
 cd "$DIR" || exit 1
 
 VERSIONS=( \
-    9.1 \
-    9.2 \
-    9.3 \
     9.4 \
     9.5 \
     9.6 \


### PR DESCRIPTION
Remove support for version on that are [no longer supported](https://www.postgresql.org/support/versioning/) by the postgre team

<img width="1346" alt="Screenshot 2019-06-14 23 37 34" src="https://user-images.githubusercontent.com/1268088/59548019-8e7df400-8efd-11e9-8dc1-85bfc5fa6575.png">

It is worth mentioning that the docker image for postgres 9.1 fails to build due an issue w/ apt-get and debian indexes.
see https://travis-ci.org/asherf/postgres_exporter/builds/546034279
<img width="1105" alt="Screenshot 2019-06-14 23 40 50" src="https://user-images.githubusercontent.com/1268088/59548042-e288d880-8efd-11e9-9105-b32942c0bfad.png">

