### PR TITLE
Use application_name column as a label

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -202,7 +202,7 @@ var builtinMetricMaps = map[string]map[string]ColumnMapping{
 		"pid":              {DISCARD, "Process ID of a WAL sender process", nil, semver.MustParseRange(">=9.2.0")},
 		"usesysid":         {DISCARD, "OID of the user logged into this WAL sender process", nil, nil},
 		"usename":          {DISCARD, "Name of the user logged into this WAL sender process", nil, nil},
-		"application_name": {DISCARD, "Name of the application that is connected to this WAL sender", nil, nil},
+		"application_name": {LABEL, "Name of the application that is connected to this WAL sender", nil, nil},
 		"client_addr":      {LABEL, "IP address of the client connected to this WAL sender. If this field is null, it indicates that the client is connected via a Unix socket on the server machine.", nil, nil},
 		"client_hostname":  {DISCARD, "Host name of the connected client, as reported by a reverse DNS lookup of client_addr. This field will only be non-null for IP connections, and only when log_hostname is enabled.", nil, nil},
 		"client_port":      {DISCARD, "TCP port number that the client is using for communication with this WAL sender, or -1 if a Unix socket is used", nil, nil},


### PR DESCRIPTION
In a k8s cluster, client_addr cannot be used to identify clients. application_name would be really useful.