### PR TITLE
Add pg_replication_is_in_recovery metric

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -1,6 +1,9 @@
 pg_replication:
-  query: "SELECT EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())) as lag"
+  query: "SELECT pg_is_in_recovery()::int as is_in_recovery, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())) as lag"
   metrics:
+    - is_in_recovery:
+        usage: "GAUGE"
+        description: "Is server in recovery mode (1 for yes, 0 for no)"
     - lag:
         usage: "GAUGE"
         description: "Replication lag behind master in seconds"


### PR DESCRIPTION
For standalone databases `pg_relication_lag` can have not null value if database was recovered after failure. Thus, to have alerts based on `pg_relication_lag` it is necessary to analyze `pg_replication_is_in_recovery`. Pseudocode should be like: `If (pg_relication_is_in_recovery == 1) then process pg_relication_lag; else continue; end if;`