### PR TITLE
Template and allowconn discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ flag. This removes all built-in metrics, and uses only metrics defined by querie
 
 ### Automatically discover databases
 To scrape metrics from all databases on a database server, the database DSN's can be dynamically discovered via the 
-`--auto-discover-databases` flag. When true, `SELECT datname FROM pg_database` is run for all configured DSN's. From the 
+`--auto-discover-databases` flag. When true, `SELECT datname FROM pg_database WHERE datallowconn = true AND datistemplate = false` is run for all configured DSN's. From the 
 result a new set of DSN's is created for which the metrics are scraped.
 
 ### Running as non-superuser

--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -1065,7 +1065,7 @@ func newDesc(subsystem, name, help string, labels prometheus.Labels) *prometheus
 }
 
 func queryDatabases(server *Server) ([]string, error) {
-	rows, err := server.db.Query("SELECT datname FROM pg_database") // nolint: safesql
+	rows, err := server.db.Query("SELECT datname FROM pg_database WHERE datallowconn = true AND datistemplate = false") // nolint: safesql
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving databases: %v", err)
 	}


### PR DESCRIPTION
Currently when using the option `auto-discover-databases`, templates and databases that does not allow connections are returned in the result leading to errors when the exporter try to connect to them.

This PR aims to get ride of them by adding a filter in the request used by the option.

The fields `datallowconn` and `datistemplate` are presented in the PG version supporter by the exporter so it do not include breaking changes 

