### PR TITLE
exclude databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ To scrape metrics from all databases on a database server, the database DSN's ca
 `--auto-discover-databases` flag. When true, `SELECT datname FROM pg_database` is run for all configured DSN's. From the 
 result a new set of DSN's is created for which the metrics are scraped.
 
+In addition, the option `--exclude-databases` adds the possibily to filter the result from the auto discovery to discard databases you do not need.
+
 ### Running as non-superuser
 
 To be able to collect metrics from `pg_stat_activity` and `pg_stat_replication`

--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -40,7 +40,6 @@ var (
 	onlyDumpMaps           = kingpin.Flag("dumpmaps", "Do not run, simply dump the maps.").Bool()
 	constantLabelsList     = kingpin.Flag("constantLabels", "A list of label=value separated by comma(,).").Default("").Envar("PG_EXPORTER_CONSTANT_LABELS").String()
 	excludeDatabases       = kingpin.Flag("exclude-databases", "A list of databases to remove when autoDiscoverDatabases is enabled").Default("").Envar("PG_EXPORTER_EXCLUDE_DATABASES").String()
-
 )
 
 // Metric name parts.
@@ -1403,12 +1402,12 @@ func getDataSources() []string {
 }
 
 func contains(a []string, x string) bool {
-        for _, n := range a {
-                if x == n {
-                        return true
-                }
-        }
-        return false
+	for _, n := range a {
+		if x == n {
+			return true
+		}
+	}
+	return false
 }
 
 func main() {

--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -924,6 +924,7 @@ func AutoDiscoverDatabases(b bool) ExporterOpt {
 	}
 }
 
+// ExcludeDatabases allows to filter out result from AutoDiscoverDatabases
 func ExcludeDatabases(s string) ExporterOpt {
 	return func(e *Exporter) {
 		e.excludeDatabases = strings.Split(s, ",")
@@ -1324,7 +1325,7 @@ func (e *Exporter) discoverDatabaseDSNs() []string {
 			continue
 		}
 		for _, databaseName := range databaseNames {
-			if Contains(e.excludeDatabases, databaseName) {
+			if contains(e.excludeDatabases, databaseName) {
 				continue
 			}
 			parsedDSN.Path = databaseName
@@ -1401,7 +1402,7 @@ func getDataSources() []string {
 	return strings.Split(dsn, ",")
 }
 
-func Contains(a []string, x string) bool {
+func contains(a []string, x string) bool {
         for _, n := range a {
                 if x == n {
                         return true

--- a/tools/src
+++ b/tools/src
@@ -1,1 +1,1 @@
-/home/will/src/go/src/github.com/wrouesnel/postgres_exporter/tools/vendor
+/Users/alex/go/src/github.com/AlexisSellier/postgres_exporter/tools/vendor


### PR DESCRIPTION
This adds an option to exclude arbitrary databases when enabling `--auto-discover-databases`