### PR TITLE
Expose pg_current_wal_lsn_bytes

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -242,6 +242,7 @@ var builtinMetricMaps = map[string]map[string]ColumnMapping{
 		"restart_lsn":              {DISCARD, "The address (LSN) of oldest WAL which still might be required by the consumer of this slot and thus won't be automatically removed during checkpoints", nil, nil},
 		"pg_current_xlog_location": {DISCARD, "pg_current_xlog_location", nil, nil},
 		"pg_current_wal_lsn":       {DISCARD, "pg_current_xlog_location", nil, semver.MustParseRange(">=10.0.0")},
+		"pg_current_wal_lsn_bytes": {GAUGE, "WAL position in bytes", nil, semver.MustParseRange(">=10.0.0")},
 		"pg_xlog_location_diff":    {GAUGE, "Lag in bytes between master and slave", nil, semver.MustParseRange(">=9.2.0 <10.0.0")},
 		"pg_wal_lsn_diff":          {GAUGE, "Lag in bytes between master and slave", nil, semver.MustParseRange(">=10.0.0")},
 		"confirmed_flush_lsn":      {DISCARD, "LSN position a consumer of a slot has confirmed flushing the data received", nil, nil},
@@ -299,6 +300,7 @@ var queryOverrides = map[string][]OverrideQuery{
 			`
 			SELECT *,
 				(case pg_is_in_recovery() when 't' then null else pg_current_wal_lsn() end) AS pg_current_wal_lsn,
+				(case pg_is_in_recovery() when 't' then null else pg_wal_lsn_diff(pg_current_wal_lsn(), pg_lsn('0/0'))::float end) AS pg_current_wal_lsn_bytes,
 				(case pg_is_in_recovery() when 't' then null else pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn)::float end) AS pg_wal_lsn_diff
 			FROM pg_stat_replication
 			`,


### PR DESCRIPTION
pg_current_wal_lsn is currently DISCARDed here: https://github.com/wrouesnel/postgres_exporter/blob/master/cmd/postgres_exporter/postgres_exporter.go#L244

I believe this is because it's currently a string value that is the position within the WAL logs, and isn't immediately useful in graphing.

This PR adds a metric `pg_current_wal_lsn_bytes`, which is the diff between the current position and the initial WAL position of `0/0` -- effectively a translation of the WAL log position into bytes, such that `rate(pg_stat_replication_pg_currentl_wal_lsn_bytes)` can be meaningful on graphs.

We use this metric to see the rate of WAL entries being created on the primary, independently of whether the primary and secondary are becoming further behind or catching up - you can then tell the difference between the WAL creating a lot more entries than normal, but replication is proceeding at the normal rate; and the WAL having the same number of entries, but replication is proceeding slower than normal.

I've considered making this a local change in a queries.yml file, which we do use for other things - `pg_stat_user_tables`, for instance, however it feels odd to have just this one `pg_stat_replication` related metric specified in there and the rest in the main codebase.

Could also consider exposing this directly as `pg_current_wal_lsn`, as we've been discarding it so long.