### PR TITLE
Don't stop generating fingerprint while encountering value with "=" sign

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -708,7 +708,7 @@ func parseFingerprint(url string) (string, error) {
 	pairs := strings.Split(dsn, " ")
 	kv := make(map[string]string, len(pairs))
 	for _, pair := range pairs {
-		splitted := strings.Split(pair, "=")
+		splitted := strings.SplitN(pair, "=", 2)
 		if len(splitted) != 2 {
 			return "", fmt.Errorf("malformed dsn %q", dsn)
 		}

--- a/cmd/postgres_exporter/postgres_exporter_test.go
+++ b/cmd/postgres_exporter/postgres_exporter_test.go
@@ -194,6 +194,10 @@ func (s *FunctionalSuite) TestParseFingerprint(c *C) {
 			fingerprint: "localhost:55432",
 		},
 		{
+			url:         "postgresql://userDsn:passwordDsn%3D@localhost:55432/?sslmode=disabled",
+			fingerprint: "localhost:55432",
+		},
+		{
 			url:         "port=1234",
 			fingerprint: "localhost:1234",
 		},


### PR DESCRIPTION
Sometimes PostgreSQL passwords contain special characters, such as `=`, since it's also allowed to be there, and it rises a problem in finger generation code, which will mistakenly report this scenario as `invalid dsn`.

This PR fixes the problem with `=` character inside the password by splitting `=` only once, so:
- The string before `=` will be treated as key.
- The string after `=` will be treated as a value.