### PR TITLE
Add support for optional namespace caching.

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter_integration_test.go
+++ b/cmd/postgres_exporter/postgres_exporter_integration_test.go
@@ -113,9 +113,12 @@ func (s *IntegrationSuite) TestUnknownMetricParsingDoesntCrash(c *C) {
 	c.Assert(exporter, NotNil)
 
 	// Convert the default maps into a list of empty maps.
-	emptyMaps := make(map[string]map[string]ColumnMapping, 0)
+	emptyMaps := make(map[string]intermediateMetricMap, 0)
 	for k := range exporter.builtinMetricMaps {
-		emptyMaps[k] = map[string]ColumnMapping{}
+		emptyMaps[k] = intermediateMetricMap{
+			map[string]ColumnMapping{},
+			0,
+		}
 	}
 	exporter.builtinMetricMaps = emptyMaps
 

--- a/cmd/postgres_exporter/postgres_exporter_test.go
+++ b/cmd/postgres_exporter/postgres_exporter_test.go
@@ -26,10 +26,13 @@ func (s *FunctionalSuite) SetUpSuite(c *C) {
 }
 
 func (s *FunctionalSuite) TestSemanticVersionColumnDiscard(c *C) {
-	testMetricMap := map[string]map[string]ColumnMapping{
+	testMetricMap := map[string]intermediateMetricMap{
 		"test_namespace": {
-			"metric_which_stays":    {COUNTER, "This metric should not be eliminated", nil, nil},
-			"metric_which_discards": {COUNTER, "This metric should be forced to DISCARD", nil, nil},
+			map[string]ColumnMapping{
+				"metric_which_stays":    {COUNTER, "This metric should not be eliminated", nil, nil},
+				"metric_which_discards": {COUNTER, "This metric should be forced to DISCARD", nil, nil},
+			},
+			0,
 		},
 	}
 
@@ -51,9 +54,9 @@ func (s *FunctionalSuite) TestSemanticVersionColumnDiscard(c *C) {
 	// nolint: dupl
 	{
 		// Update the map so the discard metric should be eliminated
-		discardableMetric := testMetricMap["test_namespace"]["metric_which_discards"]
+		discardableMetric := testMetricMap["test_namespace"].columnMappings["metric_which_discards"]
 		discardableMetric.supportedVersions = semver.MustParseRange(">0.0.1")
-		testMetricMap["test_namespace"]["metric_which_discards"] = discardableMetric
+		testMetricMap["test_namespace"].columnMappings["metric_which_discards"] = discardableMetric
 
 		// Discard metric should be discarded
 		resultMap := makeDescMap(semver.MustParse("0.0.1"), prometheus.Labels{}, testMetricMap)
@@ -72,9 +75,9 @@ func (s *FunctionalSuite) TestSemanticVersionColumnDiscard(c *C) {
 	// nolint: dupl
 	{
 		// Update the map so the discard metric should be kept but has a version
-		discardableMetric := testMetricMap["test_namespace"]["metric_which_discards"]
+		discardableMetric := testMetricMap["test_namespace"].columnMappings["metric_which_discards"]
 		discardableMetric.supportedVersions = semver.MustParseRange(">0.0.1")
-		testMetricMap["test_namespace"]["metric_which_discards"] = discardableMetric
+		testMetricMap["test_namespace"].columnMappings["metric_which_discards"] = discardableMetric
 
 		// Discard metric should be discarded
 		resultMap := makeDescMap(semver.MustParse("0.0.2"), prometheus.Labels{}, testMetricMap)

--- a/queries.yaml
+++ b/queries.yaml
@@ -114,7 +114,8 @@ pg_statio_user_tables:
         description: "Number of buffer hits in this table's TOAST table indexes (if any)"
         
 pg_database:
-  query: " SELECT pg_database.datname, pg_database_size(pg_database.datname) as size FROM pg_database" 
+  query: "SELECT pg_database.datname, pg_database_size(pg_database.datname) as size FROM pg_database"
+  cache_seconds: 30
   metrics:
     - datname:
         usage: "LABEL"


### PR DESCRIPTION
In the user queries.yml file, the created namespaces can now be optionally
cached by setting cache_seconds, which will prevent the query being re-run
within that timeframe if previous results are available.

Supercedes #211 which became unmergeable due to conflicts.