### PR TITLE
Add support for 'DATA_SOURCE_URI_FILE' envvar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ The following environment variables configure the exporter:
    an alternative to `DATA_SOURCE_NAME` which exclusively accepts the raw URI
    without a username and password component.
 
+* `DATA_SOURCE_URI_FILE`
+   The same as above but reads the URI from a file.
+
 * `DATA_SOURCE_USER`
   When using `DATA_SOURCE_URI`, this environment variable is used to specify
   the username.

--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -1488,6 +1488,7 @@ func getDataSources() []string {
 	if len(dsn) == 0 {
 		var user string
 		var pass string
+		var uri string
 
 		if len(os.Getenv("DATA_SOURCE_USER_FILE")) != 0 {
 			fileContents, err := ioutil.ReadFile(os.Getenv("DATA_SOURCE_USER_FILE"))
@@ -1510,7 +1511,17 @@ func getDataSources() []string {
 		}
 
 		ui := url.UserPassword(user, pass).String()
-		uri := os.Getenv("DATA_SOURCE_URI")
+
+		if len(os.Getenv("DATA_SOURCE_URI_FILE")) != 0 {
+			fileContents, err := ioutil.ReadFile(os.Getenv("DATA_SOURCE_URI_FILE"))
+			if err != nil {
+				panic(err)
+			}
+			uri = strings.TrimSpace(string(fileContents))
+		} else {
+			uri = os.Getenv("DATA_SOURCE_URI")
+		}
+
 		dsn = "postgresql://" + ui + "@" + uri
 
 		return []string{dsn}


### PR DESCRIPTION
Closes #326 as is provides a viable solution to use a K8S init container
to fully contruct the PostgreSQL URI and 'hand it over' to the postgres_exporter
process.