### PR TITLE
Fix problem: version metric is not exposed if DB discovery is disabled

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -1374,7 +1374,7 @@ func (e *Exporter) checkMapVersions(ch chan<- prometheus.Metric, server *Server)
 	versionDesc := prometheus.NewDesc(fmt.Sprintf("%s_%s", namespace, staticLabelName),
 		"Version string as reported by postgres", []string{"version", "short_version"}, server.labels)
 
-	if !e.disableDefaultMetrics && (server.master && e.autoDiscoverDatabases) {
+	if !e.disableDefaultMetrics && (!e.autoDiscoverDatabases || (server.master && e.autoDiscoverDatabases)) {
 		ch <- prometheus.MustNewConstMetric(versionDesc,
 			prometheus.UntypedValue, 1, versionString, semanticVersion.String())
 	}


### PR DESCRIPTION
fixes #329