### PR TITLE
Don't ignore errors in parseUserQueries

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -542,7 +542,7 @@ func parseUserQueries(content []byte) (map[string]intermediateMetricMap, map[str
 func addQueries(content []byte, pgVersion semver.Version, server *Server) error {
 	metricMaps, newQueryOverrides, err := parseUserQueries(content)
 	if err != nil {
-		return nil
+		return err
 	}
 	// Convert the loaded metric map into exporter representation
 	partialExporterMap := makeDescMap(pgVersion, server.labels, metricMaps)


### PR DESCRIPTION
Failures in parsing the user's queries are just being swallowed, which
makes troubleshooting YAML issues frustrating/impossible. I'm presuming
this was not intentional, since there is error handling code in the
function that calls this one, though it is unreachable as far as I can
tell without this change.