### PR TITLE
Have a custom prefix for each of the default metrics created by postgres_exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ The following environment variables configure the exporter:
 * `PG_EXPORTER_EXCLUDE_DATABASES`
   A comma-separated list of databases to remove when autoDiscoverDatabases is enabled. Default is empty string.
 
+* `PG_EXPORTER_METRIC_PREFIX`
+  A prefix to use for each of the default metrics exported by postgres-exporter. Default is `pg`
+
 Settings set by environment variables starting with `PG_` will be overwritten by the corresponding CLI flag if given.
 
 ### Setting the Postgres server's data source name

--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -53,6 +53,7 @@ var (
 	onlyDumpMaps           = kingpin.Flag("dumpmaps", "Do not run, simply dump the maps.").Bool()
 	constantLabelsList     = kingpin.Flag("constantLabels", "A list of label=value separated by comma(,).").Default("").Envar("PG_EXPORTER_CONSTANT_LABELS").String()
 	excludeDatabases       = kingpin.Flag("exclude-databases", "A list of databases to remove when autoDiscoverDatabases is enabled").Default("").Envar("PG_EXPORTER_EXCLUDE_DATABASES").String()
+	metricPrefix           = kingpin.Flag("metric-prefix", "A metric prefix can be used to have non-default (not \"pg\") prefixes for each of the metrics").Default("pg").Envar("PG_EXPORTER_METRIC_PREFIX").String()
 )
 
 // Metric name parts.
@@ -603,6 +604,8 @@ func makeDescMap(pgVersion semver.Version, serverLabels prometheus.Labels, metri
 					continue
 				}
 			}
+
+			namespace := strings.Replace(namespace, "pg", *metricPrefix, 1)
 
 			// Determine how to convert the column based on its usage.
 			// nolint: dupl


### PR DESCRIPTION
Fixes (#364)