### PR TITLE
Improve PostgreSQL replication lag detection

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -1,5 +1,5 @@
 pg_replication:
-  query: "SELECT EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())) as lag"
+  query: "SELECT CASE WHEN NOT pg_is_in_recovery() THEN 0 ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) END AS lag"
   master: true
   metrics:
     - lag:


### PR DESCRIPTION
In some cases master can show `pg_last_xact_replay_timestamp()` from past, which can cause the exporter to show ever-growing value for the lag. This fixes the issue.

 I've got the idea for fix from:
 * [mailing list](https://postgrespro.com/list/id/557EE9D7.50607@gmail.com)
 * [DataDog bug fix](https://github.com/DataDog/integrations-core/pull/1172/files#diff-5557a2bc9bebe6d84b8a6fa72246b83bR214)

Example (from master):

```
[local]:5432 postgres@postgres=# SELECT EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())) as lag;
+----------------+
|      lag       |
+----------------+
| 3567749.711759 |
+----------------+
(1 row)
```

Same master, fixed query:

```
[local]:5432 postgres@postgres=# SELECT CASE WHEN NOT pg_is_in_recovery() THEN 0 ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) END AS lag;
+-----+
| lag |
+-----+
|   0 |
+-----+
(1 row)
```

Master recovery status:

```
[local]:5432 postgres@postgres=# SELECT pg_is_in_recovery();
+-------------------+
| pg_is_in_recovery |
+-------------------+
| f                 |
+-------------------+
(1 row)
```

Streaming slave:

```
[local]:5432 postgres@postgres=# SELECT pg_is_in_recovery();
+-------------------+
| pg_is_in_recovery |
+-------------------+
| t                 |
+-------------------+
(1 row)

[local]:5432 postgres@postgres=# SELECT CASE WHEN NOT pg_is_in_recovery() THEN 0 ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) END AS lag;
+---------+
|   lag   |
+---------+
| 0.31566 |
+---------+
(1 row)
```

Paused slave:

```
[local]:5432 postgres@postgres=# SELECT CASE WHEN NOT pg_is_in_recovery() THEN 0 ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) END AS lag;
+--------------+
|     lag      |
+--------------+
| 28053.150006 |
+--------------+
(1 row)


[local]:5432 postgres@postgres=# SELECT pg_is_in_recovery();
+-------------------+
| pg_is_in_recovery |
+-------------------+
| t                 |
+-------------------+
(1 row)
```

From the [documentation](https://www.postgresql.org/docs/10/functions-admin.html#FUNCTIONS-RECOVERY-CONTROL):

True if recovery is still in progress.