### PR TITLE
Add pg_stat_statements view for non-superuser instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,18 @@ AS
   SELECT * FROM get_pg_stat_replication();
 
 GRANT SELECT ON postgres_exporter.pg_stat_replication TO postgres_exporter;
+
+CREATE OR REPLACE FUNCTION get_pg_stat_statements() RETURNS SETOF pg_stat_statements AS
+$$ SELECT * FROM public.pg_stat_statements; $$
+LANGUAGE sql
+VOLATILE
+SECURITY DEFINER;
+
+CREATE OR REPLACE VIEW postgres_exporter.pg_stat_statements
+AS
+  SELECT * FROM get_pg_stat_statements();
+
+GRANT SELECT ON postgres_exporter.pg_stat_statements TO postgres_exporter;
 ```
 
 > **NOTE**


### PR DESCRIPTION
Needed this to fix errors like `* collected metric "pg_stat_statements_blk_write_time_seconds" { label:<name:"datname" value:"postgres" > label:<name:"rolname" value:"postgres_exporter" > label:<name:"server" value:"localhost:5432" > counter:<value:0 > } was collected before with the same name and label values`.