### PR TITLE
Recover when connection cannot be established straight at startup

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -1503,12 +1503,12 @@ func (e *Exporter) discoverDatabaseDSNs() []string {
 			continue
 		}
 
-		dsns[dsn] = struct{}{}
 		server, err := e.servers.GetServer(dsn)
 		if err != nil {
 			log.Errorf("Error opening connection to database (%s): %v", loggableDSN(dsn), err)
 			continue
 		}
+		dsns[dsn] = struct{}{}
 
 		// If autoDiscoverDatabases is true, set first dsn as master database (Default: false)
 		server.master = true


### PR DESCRIPTION
When the connection to the PostgreSQL instance cannot be established straight at startup, a race condition can happen when autoDiscoverDatabases is true. If discoverDatabaseDSNs fails, no dsn is set as the master database, and, if scrapeDSN succeeds, checkMapVersions will have omitted the default metrics in the server metric map. The metric map won't be updated unless the version returned by the PostgreSQL instance changes. With this patch, scrapeDSN won't be run unless discoverDatabaseDSNs succeeded and thus the race condition is eliminated.