### PR TITLE
Do not try to return metric descriptors in Describe

### DIFF
--- a/cmd/postgres_exporter/postgres_exporter.go
+++ b/cmd/postgres_exporter/postgres_exporter.go
@@ -1147,29 +1147,6 @@ func (e *Exporter) setupInternalMetrics() {
 
 // Describe implements prometheus.Collector.
 func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
-	// We cannot know in advance what metrics the exporter will generate
-	// from Postgres. So we use the poor man's describe method: Run a collect
-	// and send the descriptors of all the collected metrics. The problem
-	// here is that we need to connect to the Postgres DB. If it is currently
-	// unavailable, the descriptors will be incomplete. Since this is a
-	// stand-alone exporter and not used as a library within other code
-	// implementing additional metrics, the worst that can happen is that we
-	// don't detect inconsistent metrics created by this exporter
-	// itself. Also, a change in the monitored Postgres instance may change the
-	// exported metrics during the runtime of the exporter.
-	metricCh := make(chan prometheus.Metric)
-	doneCh := make(chan struct{})
-
-	go func() {
-		for m := range metricCh {
-			ch <- m.Desc()
-		}
-		close(doneCh)
-	}()
-
-	e.Collect(metricCh)
-	close(metricCh)
-	<-doneCh
 }
 
 // Collect implements prometheus.Collector.


### PR DESCRIPTION
Since we cannot know in advance the metrics which the exporter will generate, the workaround is to run a Collect and return the metric descriptors. This is problematic when the connection to the PostgreSQL instance cannot be established straight from the start. This patch makes Describe return no descriptors, effectively turning the collector in an unchecked one, which we're in the typical use case here: https://pkg.go.dev/github.com/prometheus/client_golang/prometheus?tab=doc#hdr-Custom_Collectors_and_constant_Metrics.

Related to #415