### PR TITLE
Loongson CPU mips64le compiled through.

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -98,6 +98,7 @@ var platforms []Platform = []Platform{
 	{"linux", "amd64", ""},
 	{"linux", "386", ""},
 	{"linux", "arm64", ""},
+	{"linux", "mips64le", ""},
 	{"darwin", "amd64", ""},
 	{"darwin", "386", ""},
 	{"windows", "amd64", ".exe"},


### PR DESCRIPTION
GOOS="linux"
GOARCH="mips64le"
GOROOT="/opt/go/go1.14.6"

the issues: https://github.com/wrouesnel/postgres_exporter/issues/417
lol,I solved


I forgot to put some material on it.

[root@localhost postgres_exporter]# arch
mips64el
[root@localhost postgres_exporter]# cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 7.2 (Maipo)
[root@localhost 桌面]# uname -a
Linux localhost.localdomain 3.10.0-693.21.1.ns7.007.mips64el #1 SMP PREEMPT Wed May 23 19:09:06 CST 2018 mips64el mips64el mips64el GNU/Linux
[root@localhost postgres_exporter]# export DATA_SOURCE_NAME="postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
[root@localhost postgres_exporter]# ./postgres_exporter
INFO[0000] Established new database connection to "localhost:5432".  source="postgres_exporter.go:878"
INFO[0000] Semantic Version Changed on "localhost:5432": 0.0.0 -> 11.2.0  source="postgres_exporter.go:1405"
INFO[0000] Starting Server: :9187                        source="postgres_exporter.go:1672"

[root@localhost postgres_exporter]# curl http://localhost:9187/metrics
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
go_gc_duration_seconds{quantile="0.5"} 0
go_gc_duration_seconds{quantile="0.75"} 0
go_gc_duration_seconds{quantile="1"} 0
go_gc_duration_seconds_sum 0
go_gc_duration_seconds_count 0
go_goroutines 9
...
promhttp_metric_handler_requests_in_flight 1
promhttp_metric_handler_requests_total{code="200"} 2
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0

sorry,I have deleted the # text, it will affect the beauty.