### PR TITLE
Update queries.yml

### DIFF
--- a/queries.yaml
+++ b/queries.yaml
@@ -15,7 +15,32 @@ pg_postmaster:
         description: "Time at which postmaster started"
 
 pg_stat_user_tables:
-  query: "SELECT current_database() datname, schemaname, relname, seq_scan, seq_tup_read, idx_scan, idx_tup_fetch, n_tup_ins, n_tup_upd, n_tup_del, n_tup_hot_upd, n_live_tup, n_dead_tup, n_mod_since_analyze, COALESCE(last_vacuum, '1970-01-01Z'), COALESCE(last_vacuum, '1970-01-01Z') as last_vacuum, COALESCE(last_autovacuum, '1970-01-01Z') as last_autovacuum, COALESCE(last_analyze, '1970-01-01Z') as last_analyze, COALESCE(last_autoanalyze, '1970-01-01Z') as last_autoanalyze, vacuum_count, autovacuum_count, analyze_count, autoanalyze_count FROM pg_stat_user_tables"
+  query: |
+   SELECT
+     current_database() datname,
+     schemaname,
+     relname,
+     seq_scan,
+     seq_tup_read,
+     idx_scan,
+     idx_tup_fetch,
+     n_tup_ins,
+     n_tup_upd,
+     n_tup_del,
+     n_tup_hot_upd,
+     n_live_tup,
+     n_dead_tup,
+     n_mod_since_analyze,
+     COALESCE(last_vacuum, '1970-01-01Z') as last_vacuum, 
+     COALESCE(last_autovacuum, '1970-01-01Z') as last_autovacuum, 
+     COALESCE(last_analyze, '1970-01-01Z') as last_analyze, 
+     COALESCE(last_autoanalyze, '1970-01-01Z') as last_autoanalyze, 
+     vacuum_count, 
+     autovacuum_count, 
+     analyze_count, 
+     autoanalyze_count 
+   FROM 
+     pg_stat_user_tables
   metrics:
     - datname:
         usage: "LABEL"


### PR DESCRIPTION
Update query for pg_stat_user_tables:
* Split up to multi-line format to make it easier to read.
* Remove duplicate of column `COALESCE(last_vacuum, '1970-01-01Z')`.

Signed-off-by: Ben Kochie <superq@gmail.com>